### PR TITLE
Removed way too specific reference to line-readable-stream's main file

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var __extends = this.__extends || function (d, b) {
 ///<reference path="node_modules/line-readable-stream/LineReadableStream.d.ts"/>
 var Q = require("q");
 var net = require("net");
-var LineReadableStream = require("./node_modules/line-readable-stream/LineReadableStream");
+var LineReadableStream = require("line-readable-stream");
 var events = require("events");
 var util = require("util");
 


### PR DESCRIPTION
Code deep-referenced a file that was moved in a new version of the line-readable-stream dependency. This file also happened to be the main file (as specified in package.json). By changing the require() call to just the dependency name, this will work as long as the line-readable-stream dependency doesnt dramatically change it's API.

Original error:

Error: Cannot find module './node_modules/line-readable-stream/LineReadableStream'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/home/wybe/git/p0mp-server/node_modules/node-ts/index.js:16:26)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)

line-readable-stream version: (v1.1.4) 