### PR TITLE
Fix Queue

### DIFF
--- a/src/node-ts.ts
+++ b/src/node-ts.ts
@@ -433,6 +433,8 @@ export class TeamSpeakClient extends EventEmitter {
      * Checks the current command queue and sends them if needed.
      */
     private checkQueue(): void {
+        if (this._executing !== undefined) return;
+        
         const executing = this.queue.shift();
         if (executing) {
             this._executing = executing;


### PR DESCRIPTION
At the moment the "queue" isn't really a queue because we don't check if a `QueryCommand` is currently processed before overwriting it with the first item of the queue.
So every item is just processed right away, without even checking if we finished processing the previous command. 

This has some nasty side effects. Let's take the following example:
```js
query.send('clientlist', {}).then(r => console.log('clientlist', r.rawResponse));
query.send('serverinfo').then(r => console.log('serverinfo', r.rawResponse));
```

1. The first promise (clientlist) will never be resolved
2. The second promise (serverinfo) will resolve, but with the response of the clientlist query

I tried it out and got the following output: 
`serverinfo clid=25*** cid=8* client_database_id=1** client_nickname=[A]\sXiviD client_type=1| ...`