### PR TITLE
Make sure connect() properly throws an error if the connection attempt fails

### DIFF
--- a/src/node-ts.ts
+++ b/src/node-ts.ts
@@ -45,6 +45,10 @@ export class TeamSpeakClient extends EventEmitter {
         return new Promise((resolve, reject) => {
             this.socket = net.connect(this.port, this.host);
             this.socket.on("error", err => this.emit("error", err));
+            // We'll try to reject the promise on the first error that occures, to make sure
+            // the promise gets rejected if we get an error while connecting.
+            // (This will just do nothing if the promise is already fulfilled)
+            this.socket.once("error", err => reject(err));
             this.socket.on("close", () => this.emit("close", this.queue));
             this.socket.on("connect", () => this.onConnect(resolve, reject));
         });
@@ -361,6 +365,8 @@ export class TeamSpeakClient extends EventEmitter {
     public on(event: "clientmoved", listener: (data: any) => void): this;
     public on(event: "textmessage", listener: (data: TextMessageNotificationData) => void): this;
     public on(event: "tokenused", listener: (data: any) => void): this;
+    public on(event: "error", listener: (err: Error) => void): this;
+    public on(event: "close", listener: (queue: QueryCommand[]) => void): this;
     public on(event: string, listener: (...args: any[]) => void): this {
         return super.on(event, listener);
     }
@@ -379,6 +385,8 @@ export class TeamSpeakClient extends EventEmitter {
     public once(event: "clientmoved", listener: (data: any) => void): this;
     public once(event: "textmessage", listener: (data: TextMessageNotificationData) => void): this;
     public once(event: "tokenused", listener: (data: any) => void): this;
+    public once(event: "error", listener: (err: Error) => void): this;
+    public once(event: "close", listener: (queue: QueryCommand[]) => void): this;
     public once(event: string, listener: (...args: any[]) => void): this {
         return super.once(event, listener);
     }

--- a/src/node-ts.ts
+++ b/src/node-ts.ts
@@ -45,10 +45,10 @@ export class TeamSpeakClient extends EventEmitter {
         return new Promise((resolve, reject) => {
             this.socket = net.connect(this.port, this.host);
             this.socket.on("error", err => this.emit("error", err));
-            // We'll try to reject the promise on the first error that occures, to make sure
+            // We'll try to reject the promise if the connection closes, to make sure
             // the promise gets rejected if we get an error while connecting.
             // (This will just do nothing if the promise is already fulfilled)
-            this.socket.once("error", err => reject(err));
+            this.socket.once("close", err => reject(err));
             this.socket.on("close", () => this.emit("close", this.queue));
             this.socket.on("connect", () => this.onConnect(resolve, reject));
         });


### PR DESCRIPTION
This PR adds two things:
- Add `"close"` and `"error"` overloads to `.once()` and `.on()`
- Make sure `.connect()` properly throws an error if the connection attempt fails