### PR TITLE
Fix incorrect parameter name

### DIFF
--- a/src/node-ts.ts
+++ b/src/node-ts.ts
@@ -336,7 +336,7 @@ export class TeamSpeakClient extends EventEmitter {
     }
 
     public subscribeChannelEvents(channelId: number): Promise<CallbackData<QueryResponseItem>> {
-        return this.send("servernotifyregister", { event: "channel", channelId });
+        return this.send("servernotifyregister", { event: "channel", id: channelId });
     }
     public subscribeServerEvents(): Promise<CallbackData<QueryResponseItem>> {
         return this.send("servernotifyregister", { event: "server" });


### PR DESCRIPTION
Per [the spec](https://gist.github.com/nikeee/71e71439dd91999a3692#file-query-api-json-L1508), the parameter name needs to be `id`, not `channelId`.

If you use `subscribeChannelEvents()` right now, you will get the following error:

```
{
  cmd: 'servernotifyregister',
  options: [],
  text: 'servernotifyregister event=channel channelId=123',
  parameters: { event: 'channel', channelId: 123},
  error: { id: 1539, msg: 'parameter not found' },
  response: null,
  rawResponse: null
}
```